### PR TITLE
Add detailed javascript roadmap link

### DIFF
--- a/Slack Rules/javascript-path.md
+++ b/Slack Rules/javascript-path.md
@@ -57,11 +57,12 @@ thanks to the support of the group, to finish them with enthusiasm.
     - [ ] Use Gulp for basic build tasks
 
 ### B. Documentations for readers
-1. [Freecodecamp documents course](https://www.freecodecamp.org/news/learn-javascript-full-course/)
-
-Or 
 
 1. [The Odin Project course](https://www.theodinproject.com/courses/javascript)
 
 ### Framework
 Javascript is a wide language which has the widest community of developers, that implies that it has as a lot of frameworks, and libraries. So, to know what is good you need to learn its basics first of all, and if you love to go on with it, it gives you a lot of possibilities, you can work on desktop applications, mobile applications, web applications and robotics as well. So before jumping some frameworks, since this path is for beginners, you should first finish the basics, and the path will be updated depending on the needs.
+
+# CLICK HERE FOR THE MOST DETAILED Javascript for UI road map for an absolute beginner](https://github.com/nezago/nezago-guidelines/wiki/Javascript-for-UI-road-map-for-an-absolute-beginner)
+
+*Hppy coding!*

--- a/Slack Rules/javascript-path.md
+++ b/Slack Rules/javascript-path.md
@@ -63,6 +63,6 @@ thanks to the support of the group, to finish them with enthusiasm.
 ### Framework
 Javascript is a wide language which has the widest community of developers, that implies that it has as a lot of frameworks, and libraries. So, to know what is good you need to learn its basics first of all, and if you love to go on with it, it gives you a lot of possibilities, you can work on desktop applications, mobile applications, web applications and robotics as well. So before jumping some frameworks, since this path is for beginners, you should first finish the basics, and the path will be updated depending on the needs.
 
-# CLICK HERE FOR THE MOST DETAILED Javascript for UI road map for an absolute beginner](https://github.com/nezago/nezago-guidelines/wiki/Javascript-for-UI-road-map-for-an-absolute-beginner)
+# CLICK HERE FOR THE MOST DETAILED JAVASCRIPT FOR UI ROADMAP FOR AN ABSOLUTE BEGINNER](https://github.com/nezago/nezago-guidelines/wiki/Javascript-for-UI-road-map-for-an-absolute-beginner)
 
-*Hppy coding!*
+*Happy coding!*

--- a/Slack Rules/javascript-path.md
+++ b/Slack Rules/javascript-path.md
@@ -63,6 +63,6 @@ thanks to the support of the group, to finish them with enthusiasm.
 ### Framework
 Javascript is a wide language which has the widest community of developers, that implies that it has as a lot of frameworks, and libraries. So, to know what is good you need to learn its basics first of all, and if you love to go on with it, it gives you a lot of possibilities, you can work on desktop applications, mobile applications, web applications and robotics as well. So before jumping some frameworks, since this path is for beginners, you should first finish the basics, and the path will be updated depending on the needs.
 
-# CLICK HERE FOR THE MOST DETAILED JAVASCRIPT FOR UI ROADMAP FOR AN ABSOLUTE BEGINNER](https://github.com/nezago/nezago-guidelines/wiki/Javascript-for-UI-road-map-for-an-absolute-beginner)
+# [CLICK HERE FOR THE MOST DETAILED JAVASCRIPT FOR UI ROADMAP FOR AN ABSOLUTE BEGINNER](https://github.com/nezago/nezago-guidelines/wiki/Javascript-for-UI-road-map-for-an-absolute-beginner)
 
 *Happy coding!*


### PR DESCRIPTION
## What does it do?
It adds detailed javascript roadmap link

## Why the link?
I have written a wiki, which details well about this path, and that wiki is hosted on my github, so that is why I would like learners to get reference to that, I have edited this javascript-path added the link at the end of the file.

## Tasks
- [x] Add link
- [x] Delete freecodecamp link, as the link is moved to a detailed roadmap